### PR TITLE
:ambulance: Fixing nav launch

### DIFF
--- a/launch/navigation.launch.py
+++ b/launch/navigation.launch.py
@@ -38,7 +38,7 @@ def generate_launch_description():
         ),
         launch_arguments={
             'use_description': use_description,
-            'use_navigation_rviz': use_navigation_rviz
+            'use_rviz': use_navigation_rviz
         }.items(),
         condition=UnlessCondition(LaunchConfiguration('use_keepout_zones')),
 
@@ -50,7 +50,7 @@ def generate_launch_description():
         ),
         launch_arguments={
             'use_description': use_description,
-            'use_navigation_rviz': use_navigation_rviz
+            'use_rviz': use_navigation_rviz
         }.items(),
         condition=IfCondition(LaunchConfiguration('use_keepout_zones')),
     )


### PR DESCRIPTION
Adding the option to call use_rviz and use_description on the navigation launch file

- use_rviz calls opens rviz on the navigation launch
- use_description uses the robot description model
- fixed use_keepout_zones flag
- fixed navigation_keepout launch call